### PR TITLE
28 fixing random access code take to hunter view with blank information

### DIFF
--- a/client/src/app/hunters/join-hunt/hunter-view.component.ts
+++ b/client/src/app/hunters/join-hunt/hunter-view.component.ts
@@ -45,6 +45,14 @@ export class HunterViewComponent implements OnInit, OnDestroy {
         ).subscribe({
           next: startedHunt => {
             this.startedHunt = startedHunt;
+            if (this.startedHunt.completeHunt.tasks.length == 0) {
+              console.log('Tasks array is empty, navigating to hunters route');  // Log before navigation
+              this.router.navigate(['hunters']).then(success => {
+                console.log('Navigation success:', success);  // Log whether the navigation was successful
+              }).catch(error => {
+                console.error('Navigation error:', error);  // Log any navigation errors
+              });
+            }
             return;
           },
           error: _err => {

--- a/client/src/app/hunters/join-hunt/hunter-view.component.ts
+++ b/client/src/app/hunters/join-hunt/hunter-view.component.ts
@@ -37,33 +37,25 @@ export class HunterViewComponent implements OnInit, OnDestroy {
   ) { }
 
   ngOnInit(): void {
-      this.route.paramMap.pipe(
-        map((params: ParamMap) => params.get('accessCode')),
-        switchMap((accessCode: string) => this.hostService.getStartedHunt(accessCode)),
+    this.route.paramMap.pipe(
+      map((params: ParamMap) => params.get('accessCode')),
+      switchMap((accessCode: string) => this.hostService.getStartedHunt(accessCode)),
 
-        takeUntil(this.ngUnsubscribe)
-        ).subscribe({
-          next: startedHunt => {
-            this.startedHunt = startedHunt;
-            if (this.startedHunt.completeHunt.tasks.length == 0) {
-              console.log('Tasks array is empty, navigating to hunters route');  // Log before navigation
-              this.router.navigate(['hunters']).then(success => {
-                console.log('Navigation success:', success);  // Log whether the navigation was successful
-              }).catch(error => {
-                console.error('Navigation error:', error);  // Log any navigation errors
-              });
-            }
-            return;
-          },
-          error: _err => {
-            this.error = {
-              help: 'There is an error trying to load the tasks - Please try to run the hunt again',
-              httpResponse: _err.message,
-              message: _err.error?.title,
-            };
-          }
-        });
-    }
+      takeUntil(this.ngUnsubscribe)
+      ).subscribe({
+        next: startedHunt => {
+          this.startedHunt = startedHunt;
+          return;
+        },
+        error: _err => {
+          this.error = {
+            help: 'There is an error trying to load the tasks - Please try to run the hunt again',
+            httpResponse: _err.message,
+            message: _err.error?.title,
+          };
+        }
+      });
+  }
 
   ngOnDestroy(): void {
     this.ngUnsubscribe.next();

--- a/client/src/app/hunters/join-hunt/join-hunt.component.spec.ts
+++ b/client/src/app/hunters/join-hunt/join-hunt.component.spec.ts
@@ -1,23 +1,34 @@
-// import { ComponentFixture, TestBed } from '@angular/core/testing';
-// import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { of, throwError } from 'rxjs';
 import { JoinHuntComponent } from './join-hunt.component';
+import { HostService } from 'src/app/hosts/host.service';
+import { Router } from '@angular/router';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { StartedHunt } from 'src/app/startHunt/startedHunt';
 
 describe('JoinHuntComponent', () => {
   let component: JoinHuntComponent;
+  let hostService: jasmine.SpyObj<HostService>;
+  let router: jasmine.SpyObj<Router>;
+  let snackBar: jasmine.SpyObj<MatSnackBar>;
 
   beforeEach(() => {
-    component = new JoinHuntComponent();
+    hostService = jasmine.createSpyObj('HostService', ['getStartedHunt']);
+    router = jasmine.createSpyObj('Router', ['navigate']);
+    snackBar = jasmine.createSpyObj('MatSnackBar', ['open']);
+    component = new JoinHuntComponent(hostService, router, snackBar);
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should handle OTP change', () => {
+  it('should handle OTP change with invalid access code', () => {
     const otp = ['1', '2', '3', '4', '5', '6'];
+    hostService.getStartedHunt.and.returnValue(throwError(new Error()));
     component.handleOtpChange(otp);
     expect(component.accessCode).toEqual('123456');
-    expect(component.isAccessCodeValid).toEqual(true);
+    expect(component.isAccessCodeValid).toEqual(false);
+    expect(snackBar.open).toHaveBeenCalledWith('Invalid access code. No hunt was found.', 'Close', { duration: 6000 });
   });
 
   it('should handle OTP change with invalid length', () => {
@@ -26,6 +37,14 @@ describe('JoinHuntComponent', () => {
     expect(component.accessCode).toEqual('123');
     expect(component.isAccessCodeValid).toEqual(false);
   });
+
+  it('should handle OTP change with valid access code', () => {
+    const otp = ['1', '2', '3', '4', '5', '6'];
+    const startedHunt: StartedHunt = { accessCode: '123456', completeHunt: null };
+    hostService.getStartedHunt.and.returnValue(of(startedHunt));
+    component.handleOtpChange(otp);
+    expect(component.isAccessCodeValid).toEqual(true);
+    expect(router.navigate).toHaveBeenCalledWith(['hunt', startedHunt.accessCode]);
+  });
+
 });
-
-

--- a/client/src/app/hunters/join-hunt/join-hunt.component.spec.ts
+++ b/client/src/app/hunters/join-hunt/join-hunt.component.spec.ts
@@ -40,7 +40,10 @@ describe('JoinHuntComponent', () => {
 
   it('should handle OTP change with valid access code', () => {
     const otp = ['1', '2', '3', '4', '5', '6'];
-    const startedHunt: StartedHunt = { accessCode: '123456', completeHunt: null };
+    const startedHunt: StartedHunt = {
+      accessCode: '123456', completeHunt: null,
+      _id: ''
+    };
     hostService.getStartedHunt.and.returnValue(of(startedHunt));
     component.handleOtpChange(otp);
     expect(component.isAccessCodeValid).toEqual(true);

--- a/client/src/app/hunters/join-hunt/join-hunt.component.ts
+++ b/client/src/app/hunters/join-hunt/join-hunt.component.ts
@@ -7,7 +7,9 @@ import { RouterModule } from '@angular/router';
 import { ReactiveFormsModule } from '@angular/forms';
 import { NgxOtpInputModule } from 'ngx-otp-input';
 import { NgxOtpInputConfig } from 'ngx-otp-input';
-
+import { HostService } from 'src/app/hosts/host.service';
+import { Router } from '@angular/router';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 @Component({
   selector: 'app-join-hunt',
@@ -27,7 +29,8 @@ export class JoinHuntComponent {
 
   isAccessCodeValid = false;
 
-  accessCode = '';
+  accessCode: string;
+errorMessage: string;
   otpInputConfig:NgxOtpInputConfig = {
     otpLength: 6,
     autofocus: true,
@@ -41,9 +44,23 @@ export class JoinHuntComponent {
     }
   };
 
+  constructor(private hostService: HostService, private router: Router, private snackBar: MatSnackBar) { }
   handleOtpChange(value:string[]) : void {
     this.accessCode = value.join('');
-    this.isAccessCodeValid = this.accessCode.length === 6;
+    if (this.accessCode.length === 6) {
+      this.hostService.getStartedHunt(this.accessCode).subscribe({
+        next: startedHunt => {
+          // The access code is valid, enable the "Join Hunt" button
+          this.isAccessCodeValid = true;
+          this.router.navigate(['hunt', startedHunt.accessCode]);
+        },
+        error: err => {
+          this.isAccessCodeValid = false;
+          this.snackBar.open('Invalid access code. No hunt was found.', 'Close', {
+            duration: 6000,
+          });
+        }
+      });
+    }
   }
-
 }

--- a/client/src/app/hunters/join-hunt/join-hunt.component.ts
+++ b/client/src/app/hunters/join-hunt/join-hunt.component.ts
@@ -54,7 +54,7 @@ errorMessage: string;
           this.isAccessCodeValid = true;
           this.router.navigate(['hunt', startedHunt.accessCode]);
         },
-        error: err => {
+        error: () => {
           this.isAccessCodeValid = false;
           this.snackBar.open('Invalid access code. No hunt was found.', 'Close', {
             duration: 6000,


### PR DESCRIPTION
This PR include: 
- pop up a message warning for invalid access code on join hunt page.
- join hunt button will be enabled when the access code was checked to be valid and was in the database.
- stop navigating to random access code hunter view page with no hunt.
- test coverage for hunters/join-hunt folder 100%.

Ready to be reviewed and merge in main.
