### PR TITLE
58 change the display of tracked hunt end hunt page for host view

### DIFF
--- a/client/cypress/e2e/begin-hunt.cy.ts
+++ b/client/cypress/e2e/begin-hunt.cy.ts
@@ -32,6 +32,22 @@ describe('Begin Hunt', () => {
     page.clickSecondBeginHuntButton();
   })
 
+  it('should start hunt with the correct hunt information/end hunt page', () => {
+    page.beginHuntButton().should('exist');
+    page.beginHuntButton().click();
+    cy.wait(2000);
+    page.getAccessCode().then((accessCode) => {
+      cy.wait(1000);
+      cy.url().should('eq', `http://localhost:4200/startedHunts/${accessCode}`);
+    });
+    page.clickSecondBeginHuntButton();
+
+    page.getHuntTaskList().should('exist');
+    page.getTableTaskTitle().should('exist');
+    page.getProgressTeamTile().should('exist');
+    page.getTeamCard().should('exist');
+  })
+
   it('should click End Hunt, navigate to the host page and show message', () => {
     page.beginHuntButton().should('exist');
     page.beginHuntButton().click();

--- a/client/cypress/support/begin-hunt.po.ts
+++ b/client/cypress/support/begin-hunt.po.ts
@@ -6,6 +6,10 @@ export class BeginHuntPage {
   private readonly huntAccessCode = '.access-code-number';
   private readonly SecondBeginHuntButton = '.begin-hunt-button';
   private readonly endHuntButton = '.end-hunt-button';
+  private readonly huntTaskList = '.task-list';
+  private readonly tableTaskTitle = '.flex-1';
+  private readonly progressTeamTile = '.flex-2';
+  private readonly teamCard = '.team-card';
 
   navigateTo() {
     return cy.visit(this.baseUrl);
@@ -58,5 +62,41 @@ export class BeginHuntPage {
    */
   clickEndHuntButton() {
     return cy.get(this.endHuntButton).click();
+  }
+
+  /**
+   * Get the task list of the hunt as hunter-view.
+   *
+   * @return the value of the element with the class `.task-list`
+   */
+  getHuntTaskList() {
+    return cy.get(this.huntTaskList);
+  }
+
+  /**
+   * Get the task title from the table
+   *
+   * @return the value of the element with the class `.flex-1`
+   */
+  getTableTaskTitle() {
+    return cy.get(this.tableTaskTitle);
+  }
+
+  /**
+   * Get the progress team tile from the table
+   *
+   * @return the value of the element with the class `.flex-2`
+   */
+  getProgressTeamTile() {
+    return cy.get(this.progressTeamTile);
+  }
+
+  /**
+   * Get the team card
+   *
+   * @return the value of the element with the class `.team-card`
+   */
+  getTeamCard() {
+    return cy.get(this.teamCard);
   }
 }

--- a/client/src/app/startHunt/start-hunt.component.html
+++ b/client/src/app/startHunt/start-hunt.component.html
@@ -11,8 +11,48 @@
 } @else {
   <mat-card class="running-hunt-card">
     <mat-card-content class="running-hunt-content">
-      <h2 class="running-hunt-title">Track Progress</h2>
+      <h2 class="running-hunt-title">Hunt Is Starting</h2>
+      <h3 class="tracking-hunt-title">Access Code</h3>
+      <h5 class="tracked-access-code-number">{{ startedHunt?.accessCode }}</h5>
     </mat-card-content>
+
+    <mat-card-content class="hunt-timer"> <mat-icon matListItemIcon>av_timer</mat-icon> {{ startedHunt?.completeHunt?.hunt?.est }} min
+    </mat-card-content>
+
+    <mat-card-content class="hunt-Nof-tasks"> <mat-icon matListItemIcon>checklist</mat-icon> {{ startedHunt?.completeHunt?.hunt?.numberOfTasks }} tasks
+    </mat-card-content>
+
+    <div class="task-table">
+      <div class="flex-row header-row">
+        <div class="flex-1"> Tasks For Hunter </div>
+      </div>
+      <div class="flex-row" *ngFor="let task of startedHunt?.completeHunt?.tasks">
+        <div class="task-list">{{ task.name }}</div>
+      </div>
+
+      <div class="flex-row header-row">
+        <div class="flex-2"> Hunter Team and Their Progress </div>
+      </div>
+
+      <div class="team-box">
+        <mat-card class="team-card">
+          <mat-card-content>
+            <h2 class="team-one">Team duran</h2>
+            <h3 class ="hunter-progress"> Team Hunting Progress: </h3>
+            <mat-progress-bar class="progress-hunt-bar" mode="determinate" value="80"></mat-progress-bar>
+          </mat-card-content>
+        </mat-card>
+
+        <mat-card class="team-card">
+          <mat-card-content>
+            <h2 class="team-two">Team dussan</h2>
+            <h3 class ="hunter-progress"> Team Hunting Progress: </h3>
+            <mat-progress-bar class="progress-hunt-bar" mode="determinate" value="30"></mat-progress-bar>
+          </mat-card-content>
+        </mat-card>
+      </div>
+    </div>
+
     <mat-card-actions>
       <button mat-raised-button class = "end-hunt-button" (click)="onEndHuntClick($event)">End Hunt</button>
     </mat-card-actions>

--- a/client/src/app/startHunt/start-hunt.component.scss
+++ b/client/src/app/startHunt/start-hunt.component.scss
@@ -52,8 +52,6 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  align-items: center;
-  height: 50vh;
 }
 
 .running-hunt-content {
@@ -71,6 +69,11 @@
 .running-hunt-title {
   font-size: 5em;
   line-height: 1.0;
+  color: #00ccff;
+}
+
+.hunt-timer, .hunt-Nof-tasks {
+  margin-left: auto;
 }
 
 .end-hunt-button {
@@ -95,3 +98,140 @@
     background-color: #00ccff;
   }
 }
+
+.task-table {
+  width: 100%;
+}
+
+.flex-row {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.flex-1 {
+  flex: 3;
+  font-size: 30px;
+  font-weight: bold;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border: 1px solid black;
+  padding: 10px;
+  white-space: normal;
+  overflow: auto;
+  color: aqua;
+  background-color: darkslategray;
+  line-height: 1.5;
+}
+
+.task-list {
+  flex: 5;
+  font-size: 30px;
+  border: 1px solid black;
+  padding: 10px;
+  text-overflow: ellipsis;
+  white-space: normal;
+  overflow: auto;
+  line-height: 1.5;
+  word-wrap: break-word;
+  color: white;
+}
+
+.tracked-access-code-number {
+  font-size: 2em;
+  margin-top: 10px;
+  color: #00ccff;
+  font-weight: bold;
+  text-decoration: underline;
+}
+
+.tracking-hunt-title {
+  font-size: 3em;
+  color: #00ccff;
+  line-height: 1.5;
+}
+
+.hunt-timer {
+  font-size: 20px;
+  color: aqua;
+  font-weight: bold;
+  display: flex;
+  justify-content: flex-end;
+  padding-right: 20px;
+  padding-bottom: 10px;
+  line-height: 1.0;
+}
+
+.hunt-Nof-tasks {
+  font-size: 20px;
+  color: aqua;
+  font-weight: bold;
+  display: flex;
+  justify-content: flex-end;
+  padding-right: 20px;
+  padding-bottom: 10px;
+  line-height: 1.0;
+}
+
+.flex-2 {
+  flex: 3;
+  font-size: 30px;
+  font-weight: bold;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border: 1px solid black;
+  padding: 10px;
+  white-space: normal;
+  overflow: auto;
+  color: aqua;
+  background-color: darkslategray;
+  line-height: 1.5;
+}
+
+.team-box {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  margin-top: 20px;
+}
+
+.team-card {
+  flex: 1 0 auto;
+  margin: 10px;
+  background-color: white;
+  border: thick solid black;
+
+  /* Apply these rules when the viewport is less than 600px wide */
+  @media (max-width: 600px) {
+    .team-card {
+      flex-basis: 100%; /* Make the items take up the full width */
+    }
+  }
+}
+
+.team-one {
+  text-align: center;
+  font-size: 35px;
+  color: #00ccff;
+  font-weight: bold;
+}
+
+.team-two {
+  text-align: center;
+  font-size: 35px;
+  color: #00ccff;
+  font-weight: bold;
+}
+
+.progress-hunt-bar {
+  background-color: white;
+  border: 2px solid black;
+}
+
+.hunter-progress {
+  font-size: 30px;
+  text-decoration: underline;
+}
+
+

--- a/client/src/app/startHunt/start-hunt.component.ts
+++ b/client/src/app/startHunt/start-hunt.component.ts
@@ -6,6 +6,10 @@ import { Subject, map, switchMap, takeUntil } from "rxjs";
 import { HostService } from "../hosts/host.service";
 import { StartedHunt } from "./startedHunt";
 import { MatCard, MatCardActions, MatCardContent } from "@angular/material/card";
+import { MatIconModule } from '@angular/material/icon';
+import { CommonModule } from '@angular/common';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+
 
 @Component({
   selector: 'app-start-hunt-component',
@@ -13,7 +17,7 @@ import { MatCard, MatCardActions, MatCardContent } from "@angular/material/card"
   styleUrls: ['./start-hunt.component.scss'],
   providers: [],
   standalone: true,
-  imports: [MatCard, MatCardContent, MatCardActions]
+  imports: [MatCard, MatCardContent, MatCardActions, MatIconModule, CommonModule, MatProgressBarModule]
 })
 
 export class StartHuntComponent implements OnInit, OnDestroy {
@@ -36,7 +40,11 @@ export class StartHuntComponent implements OnInit, OnDestroy {
       takeUntil(this.ngUnsubscribe)
     ).subscribe({
       next: startedHunt => {
+        for (const task of startedHunt.completeHunt.tasks) {
+          task.photos = [];
+        }
         this.startedHunt = startedHunt;
+        console.log(this.startedHunt);
         return ;
       },
       error: _err => {

--- a/client/src/app/startHunt/start-hunt.component.ts
+++ b/client/src/app/startHunt/start-hunt.component.ts
@@ -40,9 +40,6 @@ export class StartHuntComponent implements OnInit, OnDestroy {
       takeUntil(this.ngUnsubscribe)
     ).subscribe({
       next: startedHunt => {
-        for (const task of startedHunt.completeHunt.tasks) {
-          task.photos = [];
-        }
         this.startedHunt = startedHunt;
         console.log(this.startedHunt);
         return ;


### PR DESCRIPTION
This PR include:
- Tracked Hunt page with the hunt information.
- Two team that are playing with their progress ( not actually working this is just a view of what it will be in the future ).
- e2e tests for the page.

Ready to be reviewed and merged into main.